### PR TITLE
fix: README sh path error

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python infer.py
 ### 指令微调
 
 ```
-sh script/sft_medchat.sh
+sh scripts/sft_medchat.sh
 ```
 请根据实际情况调整batch size等超参，默认为我们使用的参数。
 


### PR DESCRIPTION
根據 #20 的提醒，將 README 中 Shell Path 從 `script` 修改為 `scripts`